### PR TITLE
Load nat modules outside the ipv4 directory.

### DIFF
--- a/src/firewall.in
+++ b/src/firewall.in
@@ -219,7 +219,7 @@ for i in /lib/modules/`uname -r`/kernel/net/{,ipv4/}netfilter/{nf,ip}_conntrack_
 done
 
 status Loading NAT helper modules
-for i in /lib/modules/`uname -r`/kernel/net/ipv4/netfilter/{nf,ip}_nat_*.$EXT; do
+for i in /lib/modules/`uname -r`/kernel/net/{,ipv4/}netfilter/{nf,ip}_nat_*.$EXT; do
 	if [ -f $i ] ; then
 		module=$(basename ${i/.$EXT/})
 		# Strip {nf,ip}_nat_


### PR DESCRIPTION
Some nat modules such as the ftp module (/lib/modules/3.16.0-4-amd64/kernel/net/netfilter/nf_nat_ftp.ko) are not in the ipv4 directory. This commit should ensure those modules are loaded.
